### PR TITLE
fix

### DIFF
--- a/contracts/adapters/DPMAdapter.sol
+++ b/contracts/adapters/DPMAdapter.sol
@@ -57,7 +57,7 @@ contract DPMAdapter {
     }
 
     function permit(bytes memory triggerData, address target, bool allowance) public {
-        require(canCall(triggerData, msg.sender), "dpm-adapter/not-allowed-to-call"); //missing check to fail permit if msg.sender has no permissions
+        require(canCall(triggerData, address(this)), "dpm-adapter/not-allowed-to-call"); //missing check to fail permit if msg.sender has no permissions
 
         (address proxyAddress, ) = decode(triggerData);
 

--- a/test/aave-stop-loss-multiply.ts
+++ b/test/aave-stop-loss-multiply.ts
@@ -77,7 +77,7 @@ describe.only('AaveStoplLossCommand-Multiply', async () => {
         await guard.connect(guardDeployer).setWhitelist(aave_pa.address, true)
         await guard.connect(guardDeployer).setWhitelist(automationBotInstance.address, true)
         await guard.connect(guardDeployer).setWhitelist(aaveStopLoss.address, true)
-        await guard.connect(receiver).permit(automationExecutorInstance.address, proxyAddress, true)
+       // await guard.connect(receiver).permit(automationExecutorInstance.address, proxyAddress, true)
         /*   // TODO: take multiply poistion from mainnet
         // 1. deposit 1 eth of collateral
         const encodedOpenData = aave_pa.interface.encodeFunctionData('openPosition')


### PR DESCRIPTION
fixes 
5.1 Executing a DPM Command Reverts
Design High Version 1
A typical command execution flow of AutomationExecutor's execute() function is as follows (some
steps are omitted for clarity):
1. Giving permissions to the command address
2. Calling the command to execute
3. Disallowing the command
Note that when the automation bot permits the command address, it delegates the call to the specific
adapter. This should work because the automation bot was already permitted when the trigger was
added.
In the case of the DPMAdapter, the permit() function starts with this line