### PR TITLE
FEAT/FIX - Move permissions to bot storage

### DIFF
--- a/contracts/AutomationBot.sol
+++ b/contracts/AutomationBot.sol
@@ -326,16 +326,14 @@ contract AutomationBot is BotLike, ReentrancyGuard {
         require(command.isExecutionLegal(triggerData), "bot/trigger-execution-illegal");
         IAdapter adapter = IAdapter(getAdapterAddress(commandAddress, false));
         IAdapter executableAdapter = IAdapter(getAdapterAddress(commandAddress, true));
-        (bool status, ) = address(executableAdapter).delegatecall(
-            abi.encodeWithSelector(
-                executableAdapter.getCoverage.selector,
-                triggerData,
-                msg.sender,
-                coverageToken,
-                coverageAmount
-            )
+
+        automationBotStorage.executeCoverage(
+            triggerData,
+            msg.sender,
+            address(executableAdapter),
+            coverageToken,
+            coverageAmount
         );
-        require(status, "bot/failed-to-draw-coverage");
         {
             automationBotStorage.executePermit(triggerData, commandAddress, address(adapter), true);
         }

--- a/contracts/AutomationBot.sol
+++ b/contracts/AutomationBot.sol
@@ -215,12 +215,6 @@ contract AutomationBot is BotLike, ReentrancyGuard {
             );
 
             if (i == 0) {
-                /*    bytes memory executionData = abi.encodeWithSelector(
-                    adapter.permit.selector,
-                    triggerData[i],
-                    address(automationBotStorage),
-                    true
-                ); */
                 (bool status, ) = address(adapter).delegatecall(
                     abi.encodeWithSelector(
                         adapter.permit.selector,
@@ -344,7 +338,6 @@ contract AutomationBot is BotLike, ReentrancyGuard {
         require(status, "bot/failed-to-draw-coverage");
         {
             automationBotStorage.executePermit(triggerData, commandAddress, address(adapter), true);
-            //require(statusAllow, "bot/permit-failed");
         }
         {
             command.execute(executionData, triggerData); //command must be whitelisted

--- a/contracts/AutomationBotStorage.sol
+++ b/contracts/AutomationBotStorage.sol
@@ -93,4 +93,23 @@ contract AutomationBotStorage {
         );
         require(status, "bot-storage/permit-failed");
     }
+
+    function executeCoverage(
+        bytes memory triggerData,
+        address receiver,
+        address adapter,
+        address coverageToken,
+        uint256 coverageAmount
+    ) external auth(msg.sender) {
+        (bool status, ) = adapter.delegatecall(
+            abi.encodeWithSelector(
+                IAdapter.getCoverage.selector,
+                triggerData,
+                receiver,
+                coverageToken,
+                coverageAmount
+            )
+        );
+        require(status, "bot-storage/failed-to-draw-coverage");
+    }
 }

--- a/test/aave-stop-loss-multiply.ts
+++ b/test/aave-stop-loss-multiply.ts
@@ -291,7 +291,6 @@ describe('AaveStoplLossCommand-Multiply', async () => {
                     txData.gasUsed = txRes.gasUsed.toString()
                     console.table(txData)
                     const userData = await aavePool.getUserAccountData(proxyAddress)
-                    // TODO check a token
                     expect(+txData.usdcBalance).to.be.greaterThan(+'127000000')
                     expect(userData.totalCollateralETH).to.be.eq(0)
                     expect(userData.totalDebtETH).to.be.eq(0)

--- a/test/aave-stopl-loss.ts
+++ b/test/aave-stopl-loss.ts
@@ -120,7 +120,7 @@ describe('AaveStoplLossCommand', async () => {
                 10,
                 hardhatUtils.addresses.WETH,
                 hardhatUtils.addresses.USDC,
-                ltv.sub(1),
+                ltv.sub(2),
                 300,
             ]
             const triggerData = utils.defaultAbiCoder.encode(trigerDataTypes, trigerDecodedData)
@@ -144,7 +144,7 @@ describe('AaveStoplLossCommand', async () => {
                 10,
                 hardhatUtils.addresses.WETH,
                 hardhatUtils.addresses.USDC,
-                ltv.sub(1),
+                ltv.sub(2),
                 300,
             ]
             const triggerData = utils.defaultAbiCoder.encode(trigerDataTypes, trigerDecodedData)
@@ -240,7 +240,7 @@ describe('AaveStoplLossCommand', async () => {
                         10,
                         hardhatUtils.addresses.WETH,
                         hardhatUtils.addresses.USDC,
-                        ltv.sub(1),
+                        ltv.sub(2),
                         300,
                     ]
                     triggerData = utils.defaultAbiCoder.encode(trigerDataTypes, trigerDecodedData)
@@ -293,7 +293,7 @@ describe('AaveStoplLossCommand', async () => {
                         10,
                         hardhatUtils.addresses.WETH,
                         hardhatUtils.addresses.USDC,
-                        ltv.add(1),
+                        ltv.add(10),
                         300,
                     ]
                     triggerData = utils.defaultAbiCoder.encode(trigerDataTypes, trigerDecodedData)
@@ -320,7 +320,7 @@ describe('AaveStoplLossCommand', async () => {
                     await hre.ethers.provider.send('evm_revert', [snapshotId])
                 })
 
-                it('should NOT execute trigger', async () => {
+                it.only('should NOT execute trigger', async () => {
                     const tx = automationExecutorInstance.execute(
                         encodedClosePositionData,
 
@@ -414,7 +414,7 @@ describe('AaveStoplLossCommand', async () => {
                         10,
                         hardhatUtils.addresses.WETH,
                         hardhatUtils.addresses.USDC,
-                        ltv.sub(1),
+                        ltv.sub(2),
                         300,
                     ]
                     triggerData = utils.defaultAbiCoder.encode(trigerDataTypes, trigerDecodedData)
@@ -468,7 +468,7 @@ describe('AaveStoplLossCommand', async () => {
                         10,
                         hardhatUtils.addresses.WETH,
                         hardhatUtils.addresses.USDC,
-                        ltv.add(1),
+                        ltv.add(2),
                         300,
                     ]
                     triggerData = utils.defaultAbiCoder.encode(trigerDataTypes, trigerDecodedData)

--- a/test/aave-stopl-loss.ts
+++ b/test/aave-stopl-loss.ts
@@ -320,7 +320,7 @@ describe('AaveStoplLossCommand', async () => {
                     await hre.ethers.provider.send('evm_revert', [snapshotId])
                 })
 
-                it.only('should NOT execute trigger', async () => {
+                it('should NOT execute trigger', async () => {
                     const tx = automationExecutorInstance.execute(
                         encodedClosePositionData,
 

--- a/test/automation-aggregator.ts
+++ b/test/automation-aggregator.ts
@@ -672,7 +672,7 @@ describe('AutomationAggregatorBot', async () => {
                 false,
             ])
             await ownerProxy.connect(owner).execute(AutomationBotInstance.address, dataToSupplyRemove)
-            const status = await MakerAdapterInstance.canCall(bbTriggerData, AutomationBotInstance.address)
+            const status = await MakerAdapterInstance.canCall(bbTriggerData, AutomationBotStorageInstance.address)
             expect(status).to.equal(true)
         })
         it('should only remove approval if last param set to true - test TRUE', async () => {
@@ -685,7 +685,7 @@ describe('AutomationAggregatorBot', async () => {
                 true,
             ])
             await ownerProxy.connect(owner).execute(AutomationBotInstance.address, dataToSupplyRemove)
-            const status = await MakerAdapterInstance.canCall(bbTriggerData, AutomationBotInstance.address)
+            const status = await MakerAdapterInstance.canCall(bbTriggerData, AutomationBotStorageInstance.address)
             expect(status).to.equal(false)
         })
         it('should revert if called not through delegatecall', async () => {
@@ -725,16 +725,25 @@ describe('AutomationAggregatorBot', async () => {
         })
     })
     describe('cdpAllowed', async () => {
+        let sellExecutionRatio: number
+        let sellTargetRatio: number
+        let buyExecutionRatio: number
+        let buyTargetRatio: number
+        let bbTriggerData: BytesLike
+        let bsTriggerData: BytesLike
+
         beforeEach(async () => {
             const groupTypeId = TriggerGroupType.ConstantMultiple
             const replacedTriggerId = [0, 0]
 
             // current coll ratio : 1.859946411122229468
-            const [sellExecutionRatio, sellTargetRatio] = [toRatio(1.6), toRatio(2.53)]
-            const [buyExecutionRatio, buyTargetRatio] = [toRatio(2.55), toRatio(2.53)]
+            sellExecutionRatio = toRatio(1.6)
+            sellTargetRatio = toRatio(2.53)
+            buyExecutionRatio = toRatio(2.55)
+            buyTargetRatio = toRatio(2.53)
 
             // basic buy
-            const bbTriggerData = encodeTriggerData(
+            bbTriggerData = encodeTriggerData(
                 testCdpId,
                 TriggerType.BasicBuy,
                 buyExecutionRatio,
@@ -744,7 +753,7 @@ describe('AutomationAggregatorBot', async () => {
                 maxGweiPrice,
             )
             // basic sell
-            const bsTriggerData = encodeTriggerData(
+            bsTriggerData = encodeTriggerData(
                 testCdpId,
                 TriggerType.BasicSell,
                 sellExecutionRatio,
@@ -777,17 +786,25 @@ describe('AutomationAggregatorBot', async () => {
         it('should return true for correct operator address', async () => {
             const status = await MakerAdapterInstance.canCall(
                 dummyTriggerDataNoReRegister,
-                AutomationBotInstance.address,
+                AutomationBotStorageInstance.address,
             )
-            expect(status).to.equal(true, 'approval do not exist for AutomationBot')
+
+            expect(status).to.equal(true, 'approval does exist for AutomationBotStorageInstance')
         })
         it('should return false for correct operator address', async () => {
+            const dataToSupplyRemove = AutomationBotInstance.interface.encodeFunctionData('removeTriggers', [
+                [1, 2],
+                [bbTriggerData, bsTriggerData],
+                true,
+            ])
+            const owner = await hardhatUtils.impersonate(ownerProxyUserAddress)
+            await ownerProxy.connect(owner).execute(AutomationBotInstance.address, dataToSupplyRemove)
             const status = await MakerAdapterInstance.canCall(
                 dummyTriggerDataNoReRegister,
-                AutomationBotInstance.address,
+                AutomationBotStorageInstance.address,
             )
-            //TODO: why was false heree originally?
-            expect(status).to.equal(true, 'approval does exist for AutomationBotAggregatorInstance')
+
+            expect(status).to.equal(false, 'approval does not exist for AutomationBotStorageInstance')
         })
     })
 })

--- a/test/automation-bot.ts
+++ b/test/automation-bot.ts
@@ -261,7 +261,7 @@ describe('AutomationBot', async () => {
         it('should return true for correct operator address', async () => {
             const status = await MakerAdapterInstance.canCall(
                 dummyTriggerDataNoReRegister,
-                AutomationBotInstance.address,
+                AutomationBotStorageInstance.address,
             )
             expect(status).to.equal(true, 'approval do not exist for AutomationBot')
         })
@@ -274,7 +274,7 @@ describe('AutomationBot', async () => {
 
             const dataToSupply = MakerAdapterInstance.interface.encodeFunctionData('permit', [
                 triggerData,
-                AutomationBotInstance.address,
+                AutomationBotStorageInstance.address,
                 false,
             ])
 
@@ -282,25 +282,25 @@ describe('AutomationBot', async () => {
         })
 
         it('allows to add approval to cdp which did not have it', async () => {
-            let status = await MakerAdapterInstance.canCall(triggerData, AutomationBotInstance.address)
+            let status = await MakerAdapterInstance.canCall(triggerData, AutomationBotStorageInstance.address)
             expect(status).to.equal(false)
 
             const owner = await hardhatUtils.impersonate(ownerProxyUserAddress)
             const dataToSupply = MakerAdapterInstance.interface.encodeFunctionData('permit', [
                 triggerData,
-                AutomationBotInstance.address,
+                AutomationBotStorageInstance.address,
                 true,
             ])
 
             await ownerProxy.connect(owner).execute(MakerAdapterInstance.address, dataToSupply)
 
-            status = await MakerAdapterInstance.canCall(triggerData, AutomationBotInstance.address)
+            status = await MakerAdapterInstance.canCall(triggerData, AutomationBotStorageInstance.address)
             expect(status).to.equal(true)
         })
-        // this one is skipped becaus eit reverts, but that's not good enough for mocha
-        it.skip('should revert if called not through delegatecall', async () => {
-            const tx = await MakerAdapterInstance.permit(triggerData, AutomationBotInstance.address, true)
-            await expect(tx).to.be.reverted
+
+        it('should revert if called not through delegatecall', async () => {
+            const tx = MakerAdapterInstance.permit(triggerData, AutomationBotStorageInstance.address, true)
+            await expect(tx).to.be.revertedWith('maker-adapter/only-delegate')
         })
 
         it('should revert if called not by an owner proxy', async () => {
@@ -347,25 +347,25 @@ describe('AutomationBot', async () => {
         })
 
         it('allows to remove approval from cdp for which it was granted', async () => {
-            let status = await MakerAdapterInstance.canCall(triggerData, AutomationBotInstance.address)
+            let status = await MakerAdapterInstance.canCall(triggerData, AutomationBotStorageInstance.address)
             expect(status).to.equal(true)
 
             const owner = await hardhatUtils.impersonate(ownerProxyUserAddress)
 
             const dataToSupply = MakerAdapterInstance.interface.encodeFunctionData('permit', [
                 triggerData,
-                AutomationBotInstance.address,
+                AutomationBotStorageInstance.address,
                 false,
             ])
 
             await ownerProxy.connect(owner).execute(MakerAdapterInstance.address, dataToSupply)
 
-            status = await MakerAdapterInstance.canCall(triggerData, AutomationBotInstance.address)
+            status = await MakerAdapterInstance.canCall(triggerData, AutomationBotStorageInstance.address)
             expect(status).to.equal(false)
         })
 
         it('should revert if called not through delegatecall', async () => {
-            const tx = MakerAdapterInstance.permit(triggerData, AutomationBotInstance.address, false)
+            const tx = MakerAdapterInstance.permit(triggerData, AutomationBotStorageInstance.address, false)
             await expect(tx).to.be.reverted
         })
 
@@ -373,7 +373,7 @@ describe('AutomationBot', async () => {
             const notOwner = await hardhatUtils.impersonate(notOwnerProxyUserAddress)
             const dataToSupply = MakerAdapterInstance.interface.encodeFunctionData('permit', [
                 triggerData,
-                AutomationBotInstance.address,
+                AutomationBotStorageInstance.address,
                 false,
             ])
             const tx = notOwnerProxy.connect(notOwner).execute(MakerAdapterInstance.address, dataToSupply)
@@ -570,7 +570,7 @@ describe('AutomationBot', async () => {
 
             const status = await MakerAdapterInstance.canCall(
                 dummyTriggerDataNoReRegister,
-                AutomationBotInstance.address,
+                AutomationBotStorageInstance.address,
             )
             expect(status).to.equal(true)
         })
@@ -583,12 +583,18 @@ describe('AutomationBot', async () => {
                 false,
             ])
 
-            let status = await MakerAdapterInstance.canCall(dummyTriggerDataNoReRegister, AutomationBotInstance.address)
+            let status = await MakerAdapterInstance.canCall(
+                dummyTriggerDataNoReRegister,
+                AutomationBotStorageInstance.address,
+            )
             expect(status).to.equal(true)
 
             await ownerProxy.connect(owner).execute(AutomationBotInstance.address, dataToSupply)
 
-            status = await MakerAdapterInstance.canCall(dummyTriggerDataNoReRegister, AutomationBotInstance.address)
+            status = await MakerAdapterInstance.canCall(
+                dummyTriggerDataNoReRegister,
+                AutomationBotStorageInstance.address,
+            )
             expect(status).to.equal(true)
         })
 
@@ -600,12 +606,18 @@ describe('AutomationBot', async () => {
                 true,
             ])
 
-            let status = await MakerAdapterInstance.canCall(dummyTriggerDataNoReRegister, AutomationBotInstance.address)
+            let status = await MakerAdapterInstance.canCall(
+                dummyTriggerDataNoReRegister,
+                AutomationBotStorageInstance.address,
+            )
             expect(status).to.equal(true)
 
             await ownerProxy.connect(owner).execute(AutomationBotInstance.address, dataToSupply)
 
-            status = await MakerAdapterInstance.canCall(dummyTriggerDataNoReRegister, AutomationBotInstance.address)
+            status = await MakerAdapterInstance.canCall(
+                dummyTriggerDataNoReRegister,
+                AutomationBotStorageInstance.address,
+            )
             expect(status).to.equal(false)
         })
 

--- a/test/automation-executor.ts
+++ b/test/automation-executor.ts
@@ -272,7 +272,7 @@ describe('AutomationExecutor', async () => {
             await expect(tx).to.be.revertedWith('executor/not-authorized')
         })
 
-        it.only('should refund transaction costs if sufficient balance available on AutomationExecutor', async () => {
+        it('should refund transaction costs if sufficient balance available on AutomationExecutor', async () => {
             await (await DummyCommandInstance.changeFlags(true, true, false)).wait()
 
             const executorBalanceBefore = await hre.ethers.provider.getBalance(AutomationExecutorInstance.address)

--- a/test/automation-executor.ts
+++ b/test/automation-executor.ts
@@ -9,8 +9,17 @@ import {
     ServiceRegistry,
     TestWETH,
     ERC20,
+    AutomationBotStorage,
 } from '../typechain'
-import { getCommandHash, generateRandomAddress, getEvents, HardhatUtils, getAdapterNameHash } from '../scripts/common'
+import {
+    getCommandHash,
+    generateRandomAddress,
+    getEvents,
+    HardhatUtils,
+    getAdapterNameHash,
+    AutomationServiceName,
+    getServiceNameHash,
+} from '../scripts/common'
 import { deploySystem } from '../scripts/common/deploy-system'
 import { TriggerGroupType, TriggerType } from '@oasisdex/automation'
 
@@ -26,6 +35,7 @@ describe('AutomationExecutor', async () => {
     let ServiceRegistryInstance: ServiceRegistry
     let AutomationBotInstance: AutomationBot
     let AutomationExecutorInstance: AutomationExecutor
+    let AutomationBotStorageInstance: AutomationBotStorage
     let DummyCommandInstance: DummyCommand
     let TestWETHInstance: TestWETH
     let dai: ERC20
@@ -67,6 +77,7 @@ describe('AutomationExecutor', async () => {
         ServiceRegistryInstance = system.serviceRegistry
         AutomationBotInstance = system.automationBot
         AutomationExecutorInstance = system.automationExecutor
+        AutomationBotStorageInstance = system.automationBotStorage
 
         // Fund executor
         await owner.sendTransaction({ to: AutomationExecutorInstance.address, value: EthersBN.from(10).pow(18) })
@@ -209,6 +220,43 @@ describe('AutomationExecutor', async () => {
             await expect(tx).not.to.be.reverted
         })
 
+        it('should not revert on successful execution with updted bot and executor', async () => {
+            const AutomationBotInstance2: AutomationBot = await hardhatUtils.deployContract(
+                hre.ethers.getContractFactory('AutomationBot'),
+                [ServiceRegistryInstance.address, AutomationBotStorageInstance.address],
+            )
+            const AutomationExecutorInstance2: AutomationExecutor = await hardhatUtils.deployContract(
+                hre.ethers.getContractFactory('AutomationExecutor'),
+                [AutomationBotInstance2.address, hardhatUtils.addresses.WETH, ServiceRegistryInstance.address],
+            )
+            await (
+                await ServiceRegistryInstance.updateNamedService(
+                    getServiceNameHash(AutomationServiceName.AUTOMATION_EXECUTOR),
+                    AutomationExecutorInstance2.address,
+                )
+            ).wait()
+            await (
+                await ServiceRegistryInstance.updateNamedService(
+                    getServiceNameHash(AutomationServiceName.AUTOMATION_BOT),
+                    AutomationBotInstance2.address,
+                )
+            ).wait()
+
+            await DummyCommandInstance.changeFlags(true, true, false)
+            const tx = AutomationExecutorInstance2.execute(
+                dummyTriggerData,
+                triggerData,
+                DummyCommandInstance.address,
+                triggerId,
+                0,
+                0,
+                15000,
+                dai.address,
+            )
+
+            await expect(tx).not.to.be.reverted
+        })
+
         it('should revert with executor/not-authorized on unauthorized sender', async () => {
             await DummyCommandInstance.changeFlags(true, true, false)
             const tx = AutomationExecutorInstance.connect(notOwner).execute(
@@ -224,7 +272,7 @@ describe('AutomationExecutor', async () => {
             await expect(tx).to.be.revertedWith('executor/not-authorized')
         })
 
-        it.only('should refund transaction costs if sufficient balance available on AutomationExecutor', async () => {
+        it('should refund transaction costs if sufficient balance available on AutomationExecutor', async () => {
             await (await DummyCommandInstance.changeFlags(true, true, false)).wait()
 
             const executorBalanceBefore = await hre.ethers.provider.getBalance(AutomationExecutorInstance.address)
@@ -237,7 +285,7 @@ describe('AutomationExecutor', async () => {
                 triggerId,
                 0,
                 0,
-                -6000,
+                -2500,
                 dai.address,
             )
 
@@ -248,7 +296,7 @@ describe('AutomationExecutor', async () => {
                 triggerId,
                 0,
                 0,
-                -6000,
+                -2500,
                 dai.address,
                 { gasLimit: estimation.toNumber() + 50000, gasPrice: '100000000000' },
             )
@@ -259,12 +307,6 @@ describe('AutomationExecutor', async () => {
             const txCost = receipt.gasUsed.mul(receipt.effectiveGasPrice).toString()
             const executorBalanceAfter = await hre.ethers.provider.getBalance(AutomationExecutorInstance.address)
             const ownerBalanceAfter = await hre.ethers.provider.getBalance(await owner.getAddress())
-            console.log('executorBalanceBefore', executorBalanceBefore.toString())
-            console.log('executorBalanceAfter', executorBalanceAfter.toString())
-            console.log('executorBalanceDiff', executorBalanceBefore.sub(executorBalanceAfter).toString())
-            console.log('txCost', txCost.toString())
-            console.log('receipt.gasUsed', receipt.gasUsed.toString())
-            console.log('ownerBalanceDiff', ownerBalanceBefore.sub(ownerBalanceAfter).toString())
             expect(ownerBalanceBefore.sub(ownerBalanceAfter).mul(1000).div(txCost).toNumber()).to.be.lessThan(10) //account for some refund calculation inacurencies
             expect(ownerBalanceBefore.sub(ownerBalanceAfter).mul(1000).div(txCost).toNumber()).to.be.greaterThan(-10) //account for some refund calculation inacurencies
             expect(executorBalanceBefore.sub(executorBalanceAfter).mul(1000).div(txCost).toNumber()).to.be.greaterThan(

--- a/test/automation-executor.ts
+++ b/test/automation-executor.ts
@@ -272,7 +272,7 @@ describe('AutomationExecutor', async () => {
             await expect(tx).to.be.revertedWith('executor/not-authorized')
         })
 
-        it('should refund transaction costs if sufficient balance available on AutomationExecutor', async () => {
+        it.only('should refund transaction costs if sufficient balance available on AutomationExecutor', async () => {
             await (await DummyCommandInstance.changeFlags(true, true, false)).wait()
 
             const executorBalanceBefore = await hre.ethers.provider.getBalance(AutomationExecutorInstance.address)
@@ -285,7 +285,7 @@ describe('AutomationExecutor', async () => {
                 triggerId,
                 0,
                 0,
-                -2500,
+                -2800,
                 dai.address,
             )
 
@@ -296,7 +296,7 @@ describe('AutomationExecutor', async () => {
                 triggerId,
                 0,
                 0,
-                -2500,
+                -2800,
                 dai.address,
                 { gasLimit: estimation.toNumber() + 50000, gasPrice: '100000000000' },
             )

--- a/test/dummy-aave-trigger.ts
+++ b/test/dummy-aave-trigger.ts
@@ -13,6 +13,7 @@ import {
 import {
     AccountFactoryLike,
     AutomationBot,
+    AutomationExecutor,
     DummyAaveWithdrawCommand,
     IAccountGuard,
     IAccountImplementation,
@@ -29,6 +30,7 @@ describe('AAVE integration', async () => {
     let DPMFactory: AccountFactoryLike
     let DPMGuard: IAccountGuard
     let AutomationBotInstance: AutomationBot
+    let AutomationExecutorInstance: AutomationExecutor
     let AaveCommandInstance: DummyAaveWithdrawCommand
     let utils: HardhatUtils
     let triggerData: string
@@ -49,6 +51,7 @@ describe('AAVE integration', async () => {
 
         executorAddress = await hre.ethers.provider.getSigner(0).getAddress()
         system = await deploySystem({ utils, addCommands: true, logDebug: true })
+        AutomationExecutorInstance = system.automationExecutor
         console.log('System deployed')
         DPMFactory = await hre.ethers.getContractAt('AccountFactoryLike', utils.addresses.DPM_FACTORY) //utils.addresses.DPM_FACTORY);
         AutomationBotInstance = await hre.ethers.getContractAt('AutomationBot', utils.addresses.AUTOMATION_BOT_V2)
@@ -124,7 +127,7 @@ describe('AAVE integration', async () => {
 
         await expect(tx).to.not.be.reverted
 
-        const receipt = await (await tx).wait()
+        await (await tx).wait()
     })
 
     describe('Trigger added', async () => {
@@ -144,32 +147,26 @@ describe('AAVE integration', async () => {
             const receipt = await tx.wait()
             const addEvents = getEvents(receipt, system.automationBot.interface.getEvent('TriggerAdded'))
             triggerId = addEvents[0].args!.triggerId.toString()
-            await system.serviceRegistry.updateNamedService(
-                getServiceNameHash(AutomationServiceName.AUTOMATION_EXECUTOR),
-                executorAddress,
-            )
         })
 
         it('trigger should be immediatelly eligible', async () => {
             const status = await AaveCommandInstance.isExecutionLegal(triggerData)
             expect(status).to.be.true
         })
-        it('trigger execution should not fail', async () => {
-            const tx = DPMAccount.execute(
-                system.automationBot.address,
-                AutomationBotInstance.interface.encodeFunctionData('execute', [
-                    '0x',
-                    triggerData,
-                    AaveCommandInstance.address,
-                    triggerId,
-                    '0',
-                    utils.addresses.USDC_AAVE,
-                ]),
-                {
-                    gasLimit: 10000000,
-                },
+        it.only('trigger execution should not fail', async () => {
+            const tx0 = AutomationExecutorInstance.execute(
+                '0x',
+                triggerData,
+                AaveCommandInstance.address,
+                triggerId,
+                '0',
+                '0',
+                178000,
+                utils.addresses.USDC_AAVE,
+                { gasLimit: 3000000 },
             )
-            await expect(tx).to.not.be.reverted
+
+            await expect(tx0).to.not.be.reverted
         })
     })
 })

--- a/test/dummy-aave-trigger.ts
+++ b/test/dummy-aave-trigger.ts
@@ -153,7 +153,7 @@ describe('AAVE integration', async () => {
             const status = await AaveCommandInstance.isExecutionLegal(triggerData)
             expect(status).to.be.true
         })
-        it.only('trigger execution should not fail', async () => {
+        it('trigger execution should not fail', async () => {
             const tx0 = AutomationExecutorInstance.execute(
                 '0x',
                 triggerData,


### PR DESCRIPTION
execution permissions are moved to automation bot storage, to allow upgrades of the automation bot logic while preserving permissions from user.

`executePermit` in automationBotStorage can only be called by current automation bot