### PR TITLE
TECH-1124 - Upgrading Node.js 12 (End-of-Life) Github Actions to Node.js 16

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,10 +23,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache YARN dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         
         with:
           path: node_modules


### PR DESCRIPTION
TECH-1124 - Node.js 12 Github Actions are deprecated as Node.js 12 reached End-of-Life on April 2022. This PR upgrades them to Node.js 16