### PR TITLE
fix: aave v3 sl

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -51,6 +51,8 @@ jobs:
                   ALCHEMY_NODE: ${{ secrets.ALCHEMY_NODE }}
                   ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
                   ALCHEMY_NODE_GOERLI: ${{ secrets.ALCHEMY_NODE_GOERLI }}
+                  ONE_INCH_API_ENDPOINT: ${{ secrets.ONE_INCH_API_ENDPOINT }}
+                  ONE_INCH_API_KEY: ${{ secrets.ONE_INCH_API_KEY }}
               run: npx hardhat compile
 
             - name: test


### PR DESCRIPTION
- aave pool contract does not return the actual `ltv` of the user with `getUserAccountData` - contrary to whats stated in the documentation and natspec in the contract:
```ts
  /**
   * @notice Returns the user account data across all the reserves
   * @param user The address of the user
   * @return totalCollateralBase The total collateral of the user in the base currency used by the price feed
   * @return totalDebtBase The total debt of the user in the base currency used by the price feed
   * @return availableBorrowsBase The borrowing power left of the user in the base currency used by the price feed
   * @return currentLiquidationThreshold The liquidation threshold of the user
   * @return ltv The loan to value of The user
   * @return healthFactor The current health factor of the user
   */
``` 
due to that the ltv calcualtion is changed to 

```ts
        (uint256 totalCollateralBase, uint256 totalDebtBase, , , , ) = lendingPool
            .getUserAccountData(stopLossTriggerData.positionAddress);

        // Calculate the loan-to-value (LTV) ratio for Aave V3
        // LTV is the ratio of the total debt to the total collateral, expressed as a percentage
        // The result is multiplied by 10000 to preserve precision
        // eg 0.67 (67%) LTV is stored as 6700
        uint256 ltv = (totalDebtBase * 10000) / totalCollateralBase;
```
